### PR TITLE
Enable usage of LDL_DISABLE_POINTONE in ldl_sm.h via include

### DIFF
--- a/include/ldl_sm.h
+++ b/include/ldl_sm.h
@@ -28,6 +28,7 @@
 extern "C" {
 #endif
 
+#include "ldl_platform.h"
 #include "ldl_sm_internal.h"
 
 #include <stdint.h>


### PR DESCRIPTION
Enable usage of LDL_DISABLE_POINTONE in ldl_sm.h via include in "ldl.platform.h".
Otherwise the symbol was not known in ldl_sm.c.
(Note: This is my 1st pull request, please excuse any errors I made.)