### PR TITLE
Fix calling app_handler for LDL_MAC_RX.

### DIFF
--- a/src/ldl_mac.c
+++ b/src/ldl_mac.c
@@ -1260,7 +1260,7 @@ static void processRX(struct ldl_mac *self)
                 fopts = frame.opts;
                 foptsLen = frame.optsLen;
 
-                if((frame.data != NULL) && (frame.port == 0U)){
+                if(frame.data != NULL){
 
                     if(frame.port == 0U){
 


### PR DESCRIPTION
The handler was not called, although a message was received.