### PR TITLE
Enhancement: Save memory for LoRaWAN 1.0

### DIFF
--- a/include/ldl_mac.h
+++ b/include/ldl_mac.h
@@ -426,7 +426,14 @@ struct ldl_mac_session {
     uint8_t session_version;    /* set to currentSessionVersion */
     bool joined;
     bool adr;
+    /* 0: 1.0 backend, 1: 1.1 backend */
+#ifndef LDL_DISABLE_POINTONE
     uint8_t version;
+#define SESS_VERSION(sess) (sess.version)
+#else
+    // constant value, so the compiler can optimize out unneeded code paths
+#define SESS_VERSION(sess) (0)
+#endif
 
     enum ldl_region region;
 

--- a/src/ldl_frame.c
+++ b/src/ldl_frame.c
@@ -269,9 +269,11 @@ static bool getFrameType(uint8_t tag, enum ldl_frame_type *type)
         case FRAME_TYPE_DATA_CONFIRMED_DOWN:
             *type = FRAME_TYPE_DATA_CONFIRMED_DOWN;
             break;
+#ifndef LDL_DISABLE_POINTONE
         case FRAME_TYPE_REJOIN_REQ:
             *type = FRAME_TYPE_REJOIN_REQ;
             break;
+#endif            
         default:
             retval = false;
             break;

--- a/src/ldl_mac.c
+++ b/src/ldl_mac.c
@@ -534,10 +534,11 @@ uint8_t LDL_MAC_mtu(const struct ldl_mac *self)
         overhead += commandIsPending(self, LDL_CMD_NEW_CHANNEL) ? LDL_MAC_sizeofCommandUp(LDL_CMD_NEW_CHANNEL) : 0U;
         overhead += commandIsPending(self, LDL_CMD_RX_TIMING_SETUP) ? LDL_MAC_sizeofCommandUp(LDL_CMD_RX_TIMING_SETUP) : 0U;
         overhead += commandIsPending(self, LDL_CMD_DL_CHANNEL) ? LDL_MAC_sizeofCommandUp(LDL_CMD_DL_CHANNEL) : 0U;
-
+#ifndef LDL_DISABLE_POINTONE
         overhead += commandIsPending(self, LDL_CMD_REKEY) ? LDL_MAC_sizeofCommandUp(LDL_CMD_REKEY) : 0U;
         overhead += commandIsPending(self, LDL_CMD_ADR_PARAM_SETUP) ? LDL_MAC_sizeofCommandUp(LDL_CMD_ADR_PARAM_SETUP) : 0U;
         overhead += commandIsPending(self, LDL_CMD_REJOIN_PARAM_SETUP) ? LDL_MAC_sizeofCommandUp(LDL_CMD_REJOIN_PARAM_SETUP) : 0U;
+#endif        
     }
 
     return (overhead > max) ? 0 : (max - overhead);
@@ -1507,7 +1508,7 @@ static enum ldl_mac_status externalDataCommand(struct ldl_mac *self, bool confir
                                 LDL_DEBUG(self->app, "%s: preparing data frame", __FUNCTION__)
 
                                 /* sticky commands */
-
+#ifndef LDL_DISABLE_POINTONE
                                 if(commandIsPending(self, LDL_CMD_REKEY)){
 
                                     struct ldl_rekey_ind ind = {
@@ -1518,7 +1519,7 @@ static enum ldl_mac_status externalDataCommand(struct ldl_mac *self, bool confir
 
                                     LDL_DEBUG(self->app, "%s: adding rekey_ind: version=%u", __FUNCTION__, self->ctx.version)
                                 }
-
+#endif
                                 if(commandIsPending(self, LDL_CMD_RX_PARAM_SETUP)){
 
                                     LDL_MAC_putRXParamSetupAns(&s, &self->ctx.rx_param_setup_ans);
@@ -1586,7 +1587,7 @@ static enum ldl_mac_status externalDataCommand(struct ldl_mac *self, bool confir
                                         self->ctx.new_channel_ans.channelFreqOK ? "true" : "false"
                                     )
                                 }
-
+#ifndef LDL_DISABLE_POINTONE
                                 if(commandIsPending(self, LDL_CMD_REJOIN_PARAM_SETUP)){
 
                                     LDL_MAC_putRejoinParamSetupAns(&s, &self->ctx.rejoin_param_setup_ans);
@@ -1605,6 +1606,7 @@ static enum ldl_mac_status externalDataCommand(struct ldl_mac *self, bool confir
 
                                     LDL_DEBUG(self->app, "%s: adding adr_param_setup_ans", __FUNCTION__)
                                 }
+#endif
 
                                 if(commandIsPending(self, LDL_CMD_TX_PARAM_SETUP)){
 
@@ -2147,6 +2149,7 @@ static void processCommands(struct ldl_mac *self, const uint8_t *in, uint8_t len
         }
             break;
 #endif
+#ifndef LDL_DISABLE_POINTONE
         case LDL_CMD_ADR_PARAM_SETUP:
 
             LDL_DEBUG(self->app, "%s: adr_param_setup: limit_exp=%u delay_exp=%u",
@@ -2202,6 +2205,7 @@ static void processCommands(struct ldl_mac *self, const uint8_t *in, uint8_t len
             self->ctx.rejoin_param_setup_ans.timeOK = false;
             setPendingCommand(self, LDL_CMD_REJOIN_PARAM_SETUP);
             break;
+#endif            
         }
     }
 

--- a/src/ldl_mac.c
+++ b/src/ldl_mac.c
@@ -1217,7 +1217,9 @@ static void processRX(struct ldl_mac *self)
                 }
 
                 self->ctx.devAddr = frame.devAddr;
+#ifndef LDL_DISABLE_POINTONE
                 self->ctx.version = (frame.optNeg) ? 1U : 0U;
+#endif
 
                 /* cache this so that the session keys can be re-derived */
                 self->ctx.netID = frame.netID;
@@ -1226,7 +1228,7 @@ static void processRX(struct ldl_mac *self)
 
                 self->joinNonce = frame.joinNonce;
 
-                if(self->ctx.version > 0){
+                if(SESS_VERSION(self->ctx) > 0){
 
                     setPendingCommand(self, LDL_CMD_REKEY);
                 }
@@ -2725,7 +2727,7 @@ static void downlinkMissingHandler(struct ldl_mac *self)
             if(selectChannel(self, self->tx.rate, self->tx.chIndex, ms_until_next, &self->tx.chIndex, &self->tx.freq)){
 
                 /* MIC must be refreshed when channel changes */
-                if(self->ctx.version > 0){
+                if(SESS_VERSION(self->ctx) > 0){
 
                     LDL_OPS_micDataFrame(self, self->buffer, self->bufferLen);
                 }
@@ -2757,7 +2759,7 @@ static void downlinkMissingHandler(struct ldl_mac *self)
             if((self->band[LDL_BAND_GLOBAL] < LDL_Region_getMaxDCycleOffLimit(self->ctx.region)) && selectChannel(self, self->tx.rate, self->tx.chIndex, LDL_Region_getMaxDCycleOffLimit(self->ctx.region), &self->tx.chIndex, &self->tx.freq)){
 
                 /* must recalculate the MIC for V1.1 since channel changes */
-                if(self->ctx.version > 0){
+                if(SESS_VERSION(self->ctx) > 0){
 
                     LDL_OPS_micDataFrame(self, self->buffer, self->bufferLen);
                 }

--- a/src/ldl_mac_commands.c
+++ b/src/ldl_mac_commands.c
@@ -42,11 +42,13 @@ static const struct type_to_tag tags[] = {
     {8U, LDL_CMD_RX_TIMING_SETUP},
     {9U, LDL_CMD_TX_PARAM_SETUP},
     {10U, LDL_CMD_DL_CHANNEL},
+    {13U, LDL_CMD_DEVICE_TIME},
+#ifndef LDL_DISABLE_POINTONE
     {11U, LDL_CMD_REKEY},
     {12U, LDL_CMD_ADR_PARAM_SETUP},
-    {13U, LDL_CMD_DEVICE_TIME},
     {14U, LDL_CMD_FORCE_REJOIN},
     {15U, LDL_CMD_REJOIN_PARAM_SETUP}
+#endif    
 };
 
 /* functions **********************************************************/
@@ -286,6 +288,13 @@ bool LDL_MAC_getDownCommand(struct ldl_stream *s, struct ldl_downstream_cmd *cmd
             }
                 break;
 
+            case LDL_CMD_DEVICE_TIME:
+
+                (void)LDL_Stream_getU32(s, &cmd->fields.deviceTime.seconds);
+                (void)LDL_Stream_getU8(s, &cmd->fields.deviceTime.fractions);
+                break;
+
+#ifndef LDL_DISABLE_POINTONE
             case LDL_CMD_REKEY:
 
                 (void)LDL_Stream_getU8(s, &cmd->fields.rekey.version);
@@ -301,12 +310,6 @@ bool LDL_MAC_getDownCommand(struct ldl_stream *s, struct ldl_downstream_cmd *cmd
                 cmd->fields.adrParamSetup.limit_exp = buf >> 4;
                 cmd->fields.adrParamSetup.delay_exp = buf & 0xfU;
             }
-                break;
-
-            case LDL_CMD_DEVICE_TIME:
-
-                (void)LDL_Stream_getU32(s, &cmd->fields.deviceTime.seconds);
-                (void)LDL_Stream_getU8(s, &cmd->fields.deviceTime.fractions);
                 break;
 
             case LDL_CMD_FORCE_REJOIN:
@@ -332,6 +335,7 @@ bool LDL_MAC_getDownCommand(struct ldl_stream *s, struct ldl_downstream_cmd *cmd
                 cmd->fields.rejoinParamSetup.maxCountN = buf & 0xfU;
             }
                 break;
+#endif
             }
         }
     }

--- a/src/ldl_ops.c
+++ b/src/ldl_ops.c
@@ -55,7 +55,7 @@ void LDL_OPS_syncDownCounter(struct ldl_mac *self, uint8_t port, uint16_t counte
 
     derived = deriveDownCounter(self, port, counter);
 
-    if((self->ctx.version > 0U) && (port == 0U)){
+    if((SESS_VERSION(self->ctx) > 0U) && (port == 0U)){
 
         self->ctx.nwkDown = (uint16_t)(derived >> 16);
     }
@@ -79,7 +79,7 @@ void LDL_OPS_deriveKeys(struct ldl_mac *self)
 
     self->sm_interface->begin_update_session_key(self->sm);
     {
-        if(self->ctx.version == 0U){
+        if(SESS_VERSION(self->ctx) == 0U){
 
             /* ptr[0] below */
             pos = 1U;
@@ -161,7 +161,7 @@ uint8_t LDL_OPS_prepareData(struct ldl_mac *self, const struct ldl_frame_data *f
         struct ldl_block A;
 
         /* encrypt fopt (LoRaWAN 1.1) */
-        if(self->ctx.version == 1U){
+        if(SESS_VERSION(self->ctx) == 1U){
 
 #ifdef LDL_ENABLE_POINTONE_ERRATA_A1
             /* as per errata 26 Jan 2018 */
@@ -195,7 +195,7 @@ void LDL_OPS_micDataFrame(struct ldl_mac *self, void *buffer, uint8_t size)
 
     micF = self->sm_interface->mic(self->sm, LDL_SM_KEY_FNWKSINT, &B0, sizeof(B0.value), buffer, size - sizeof(micF));
 
-    if(self->ctx.version == 1U){
+    if(SESS_VERSION(self->ctx) == 1U){
 
         micS = self->sm_interface->mic(self->sm, LDL_SM_KEY_SNWKSINT, &B1, sizeof(B1.value), buffer, size - sizeof(micS));
 
@@ -316,7 +316,7 @@ bool LDL_OPS_receiveFrame(struct ldl_mac *self, struct ldl_frame_down *f, uint8_
         case FRAME_TYPE_DATA_CONFIRMED_DOWN:
 
             if(
-                ((self->ctx.version > 0) && (self->op == LDL_OP_REJOINING))
+                ((SESS_VERSION(self->ctx) > 0) && (self->op == LDL_OP_REJOINING))
                 ||
                 (self->op  == LDL_OP_DATA_UNCONFIRMED)
                 ||
@@ -332,7 +332,7 @@ bool LDL_OPS_receiveFrame(struct ldl_mac *self, struct ldl_frame_down *f, uint8_
                     struct ldl_block B;
                     struct ldl_block A;
 
-                    if((self->ctx.version == 1U) && f->ack){
+                    if((SESS_VERSION(self->ctx) == 1U) && f->ack){
 
                         initB(&B, (self->ctx.up-1U), 0U, 0U, false, f->devAddr, counter, len-sizeof(mic));
                     }
@@ -346,7 +346,7 @@ bool LDL_OPS_receiveFrame(struct ldl_mac *self, struct ldl_frame_down *f, uint8_
                     if(mic == f->mic){
 
                         /* V1.1 encrypts the opts */
-                        if(self->ctx.version == 1U){
+                        if(SESS_VERSION(self->ctx) == 1U){
 
 #ifdef LDL_ENABLE_POINTONE_ERRATA_A1
                             /* as per errata 26 Jan 2018 */
@@ -426,7 +426,7 @@ static void initB(struct ldl_block *b, uint16_t confirmCounter, uint8_t rate, ui
 
 static uint32_t deriveDownCounter(struct ldl_mac *self, uint8_t port, uint16_t counter)
 {
-    uint32_t mine = ((self->ctx.version > 0U) && (port == 0U)) ? (uint32_t)self->ctx.nwkDown : (uint32_t)self->ctx.appDown;
+    uint32_t mine = ((SESS_VERSION(self->ctx) > 0U) && (port == 0U)) ? (uint32_t)self->ctx.nwkDown : (uint32_t)self->ctx.appDown;
 
     mine = mine << 16;
 

--- a/src/ldl_ops.c
+++ b/src/ldl_ops.c
@@ -251,6 +251,7 @@ bool LDL_OPS_receiveFrame(struct ldl_mac *self, struct ldl_frame_down *f, uint8_
 
                 if(LDL_Frame_decode(f, in, len)){
 
+#ifndef LDL_DISABLE_POINTONE
                     if(f->optNeg){
 
                         if(f->joinNonce >= self->joinNonce){
@@ -289,8 +290,9 @@ bool LDL_OPS_receiveFrame(struct ldl_mac *self, struct ldl_frame_down *f, uint8_
                             LDL_DEBUG(self->app, "%s: invalid joinNonce", __FUNCTION__)
                         }
                     }
-                    else{
-
+                    else
+#endif                    
+                        {
                         mic = self->sm_interface->mic(self->sm, LDL_SM_KEY_NWK, NULL, 0U, in, len-sizeof(mic));
 
                         if(f->mic == mic){


### PR DESCRIPTION
Disable some code paths and variables when compiled with LDL_DISABLE_POINTONE.
It removes some messages/operations not used in LoRaWAN 1.0 clients.
This saves further 12 bytes RAM and 1460 bytes flash for AVR.
