### PR TITLE
Bug/Enhancement: Handle CONFIRMED DATA DOWN messages.

### DIFF
--- a/include/ldl_mac.h
+++ b/include/ldl_mac.h
@@ -471,6 +471,7 @@ struct ldl_mac_session {
     uint32_t joinNonce;
     uint16_t devNonce;
     uint16_t pending_cmds;
+    uint8_t  pending_ACK;   /** a CONFIRMED DATA message received, answer with ACK */
 };
 
 /** data service invocation options */

--- a/src/ldl_mac.c
+++ b/src/ldl_mac.c
@@ -932,6 +932,9 @@ static void processTX(struct ldl_mac *self)
 
     if(LDL_MAC_inputCheck(self, LDL_INPUT_TX_COMPLETE, &error)){
 
+        /* reset ACK flag after transmission */
+        self->ctx.pending_ACK = 0U;
+
         /* the wait interval is always measured in whole seconds */
         waitSeconds = (self->op == LDL_OP_JOINING) ? LDL_Region_getJA1Delay(self->ctx.region) : self->ctx.rx1Delay;
 
@@ -1248,8 +1251,10 @@ static void processRX(struct ldl_mac *self)
                 self->op = LDL_OP_NONE;
                 break;
 
-            case FRAME_TYPE_DATA_UNCONFIRMED_DOWN:
             case FRAME_TYPE_DATA_CONFIRMED_DOWN:
+                self->ctx.pending_ACK = 1U;
+                /* fallthrough */
+            case FRAME_TYPE_DATA_UNCONFIRMED_DOWN:
 
                 LDL_OPS_syncDownCounter(self, frame.port, frame.counter);
 
@@ -1496,6 +1501,7 @@ static enum ldl_mac_status externalDataCommand(struct ldl_mac *self, bool confir
                             f.adr = self->ctx.adr;
                             f.adrAckReq = self->adrAckReq;
                             f.port = port;
+                            f.ack = self->ctx.pending_ACK;
 
                             /* 1.1 has to awkwardly re-calculate the MIC when a frame is retried on a
                              * different channel and the counter is a parameter */


### PR DESCRIPTION
When we receive confirmed downlink message, the node must acknowlege that with the ACK bit. Otherwise the network sends the message infinitely, even after a new join. This is a serious issue, therefore I mark it as bug.

On the other side, this is only a proposal for a solution. My first idea was it to handle as a pending MAC command, that should fit quite well and should not use more RAM, when we have not more than 16 different commands to store. But I decided to use a clean solution. So I introduced another variable, that can be renamed and also hold other boolean values.

Feel free to find a better solution.