### PR TITLE
uint32_t system_rand(void *app)

### DIFF
--- a/examples/doxygen/example.c
+++ b/examples/doxygen/example.c
@@ -42,7 +42,7 @@ extern void enable_interrupts(void);
 void app_handler(void *app, enum ldl_mac_response_type type, const union ldl_mac_response_arg *arg);
 
 uint32_t system_ticks(void *app);
-unsigned int system_rand(void *app);
+uint32_t system_rand(void *app);
 
 int main(void)
 {
@@ -201,11 +201,11 @@ uint32_t system_ticks(void *app)
     return 0;
 }
 
-unsigned int system_rand(void *app)
+uint32_t system_rand(void *app)
 {
     (void)app;
 
-    return rand();
+    return (uint32_t)rand();
 }
 
 void dio0_rising_edge_isr(void)


### PR DESCRIPTION
arg.rand expects uint32_t as return type. Example corrected to support uint32_t return type for system_rand function