### PR TITLE
Fix frequency calculation for channels > 64

### DIFF
--- a/src/ldl_region.c
+++ b/src/ldl_region.c
@@ -350,7 +350,7 @@ bool LDL_Region_getChannel(enum ldl_region region, uint8_t chIndex, uint32_t *fr
         }
         else if(chIndex < 72U){
 
-            *freq = U32(903000000) + ( U32(200000) * U32(chIndex - U32(64)));
+            *freq = U32(903000000) + ( U32(1600000) * U32(chIndex - U32(64)));
             *minRate = 4U;
             *maxRate = 4U;
         }
@@ -373,7 +373,7 @@ bool LDL_Region_getChannel(enum ldl_region region, uint8_t chIndex, uint32_t *fr
         }
         else if(chIndex < 72U){
 
-            *freq = U32(915900000) + ( U32(200000) * (U32(chIndex) - U32(64)));
+            *freq = U32(915900000) + ( U32(1600000) * (U32(chIndex) - U32(64)));
             *minRate = 6U;
             *maxRate = 6U;
         }


### PR DESCRIPTION
The math to obtain the frequency of the channels above 64 was wrong for AU915-928 and US902-928.

![image](https://github.com/cjhdev/lora_device_lib/assets/2846883/e400bc98-c862-46b7-ac98-980fac0ddbcf)

![image](https://github.com/cjhdev/lora_device_lib/assets/2846883/a2d1f1da-a2c2-4d57-a32d-820c06254b2b)

I was testing your library with a RFM95M, and I've found out after debugging that I was loosing packets because sometimes the TX frequency was wrong (916.1MHz). This PR fixes that.