### PR TITLE
Fix channel selection for AU915-928 US902-928

### DIFF
--- a/src/ldl_mac.c
+++ b/src/ldl_mac.c
@@ -101,7 +101,7 @@ static uint8_t requiredRate(uint8_t desired, uint8_t min, uint8_t max);
 static void selectJoinChannelAndRate(struct ldl_mac *self, struct ldl_mac_tx *tx);
 static void registerTime(struct ldl_mac *self, const struct ldl_mac_tx *tx);
 static bool getChannel(const struct ldl_mac *self, uint8_t chIndex, uint32_t *freq, uint8_t *minRate, uint8_t *maxRate);
-static bool isAvailable(const struct ldl_mac *self, uint8_t chIndex, uint32_t limit);
+static bool isAvailable(const struct ldl_mac *self, uint8_t chIndex, uint32_t limit, uint8_t desired_rate);
 static void initSession(struct ldl_mac *self, enum ldl_region region);
 static void forgetNetwork(struct ldl_mac *self);
 static bool setChannel(struct ldl_mac *self, uint8_t chIndex, uint32_t freq, uint8_t minRate, uint8_t maxRate);
@@ -2618,7 +2618,7 @@ static bool selectChannel(const struct ldl_mac *self, uint8_t desired_rate, uint
     /* count number of available channels for this rate */
     for(i=0; i < LDL_Region_numChannels(self->ctx.region); i++){
 
-        if(isAvailable(self, i, limit)){
+        if(isAvailable(self, i, limit, desired_rate)){
 
             if(i == self->tx.chIndex){
 
@@ -2674,7 +2674,7 @@ static bool selectChannel(const struct ldl_mac *self, uint8_t desired_rate, uint
     return retval;
 }
 
-static bool isAvailable(const struct ldl_mac *self, uint8_t chIndex, uint32_t limit)
+static bool isAvailable(const struct ldl_mac *self, uint8_t chIndex, uint32_t limit, uint8_t desired_rate)
 {
     bool retval = false;
     uint32_t freq;
@@ -2686,7 +2686,7 @@ static bool isAvailable(const struct ldl_mac *self, uint8_t chIndex, uint32_t li
 
         if(getChannel(self, chIndex, &freq, &minRate, &maxRate)){
 
-            if(freq > 0U){
+            if((freq > 0U) && (desired_rate >= minRate && desired_rate <= maxRate)){
 
                 if(LDL_Region_getBand(self->ctx.region, freq, &band)){
 


### PR DESCRIPTION
When selecting the channel to transmit, the library is omitting that not all channels can use all SF. That is the case for AU915-928 and US902-928. I noticed that TTN was forcing a SF7 (with ADR) but something my device was transmitting at SF8BW500 (channel 65). Immediately after that TX, TTN was sending a new ADR command to use SF7 again. 

After debugging the library, I've found out that the `selectChannel` function was selecting any available channel, regardless if the desired data rate was obtainable or not (the function `requiredRate` was approximating the closest data rate, which I'm not sure if it's valid, at least TTN didn't like it). I've added a new parameter (`desired_rate`) to the function `isAvailable` to check if the required channel index is compatible with the desired SF. Probably the `selectChannel` function needs a refactoring. But for now I think this works fine. 

![image](https://github.com/cjhdev/lora_device_lib/assets/2846883/3a41597f-c1c8-4cbc-9fc8-f5439a2bd651)

![image](https://github.com/cjhdev/lora_device_lib/assets/2846883/847a57c3-ab27-4264-b741-f3f68cb1e214)

